### PR TITLE
chore: rename release binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
     goos:
       - linux
       - darwin
+    binary: daylog
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
want the binary named `daylog`, not `daylog-cli`