### PR TITLE
chore: organize logs into projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ To view today's file, run `daylog show`.
 
 To interact with a past or future log supply a date (`daylog show -- 2023/01/07`), or a more casual realtive reference, "tomorrow", "yesterday", "1 day ago", etc.
 
+### Log storage
+
+Logs are stored in `$XDG_DATA_HOME/daylog`.
+
 ## Installation
 
 ### Install a prebuilt binary

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,15 +8,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version, commit string
+type Config struct {
+	Project string
+}
+
+var (
+	version, commit string
+	config          Config
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "daylog",
 	Short: "A tool for keeping track of what you did today",
-	Long:  `DayLog: Fighter of the Night Log!`,
+	Long:  "DayLog: Fighter of the Night Log! A tool for keeping track of what you did today, yesterday, and tomorrow",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		dl, err := daylog.New(args)
+		dl, err := daylog.New(args, config.Project)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -27,8 +34,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+// entrypoint
 func Execute(v, c string) {
 	version, commit = v, c
 	err := rootCmd.Execute()
@@ -37,14 +43,11 @@ func Execute(v, c string) {
 	}
 }
 
-// func init() {
-// Here you will define your flags and configuration settings.
-// Cobra supports persistent flags, which, if defined here,
-// will be global for your application.
+func init() {
+	// global flags
+	rootCmd.PersistentFlags().StringVarP(&config.Project, "project", "p", "default", "The daylog project to use")
 
-// rootCmd.PersistentFlags().StringVarP(&logDir, "dir", "d", dataDir, "--dir log/directory")
-
-// Cobra also supports local flags, which will only run
-// when this action is called directly.
-// rootCmd.Flags().StringVarP(&logDir, "dir", "d", "./", "--dir log/directory")
-// }
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	// rootCmd.Flags().StringVarP(&logDir, "dir", "d", "./", "--dir log/directory")
+}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -17,7 +17,7 @@ var showCmd = &cobra.Command{
 	Short: "Display today's log",
 	Long:  "Display today's log",
 	Run: func(cmd *cobra.Command, args []string) {
-		dl, err := daylog.New(args)
+		dl, err := daylog.New(args, config.Project)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -22,14 +22,14 @@ type DayLog struct {
 	Date *time.Time
 }
 
-func New(args []string) (*DayLog, error) {
+func New(args []string, project string) (*DayLog, error) {
 	t, err := parseDateFromArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
 	year, month, day := t.Year(), int(t.Month()), t.Day()
-	file, err := resolveLogPath(year, month, day)
+	file, err := resolveLogPath(project, year, month, day)
 	if err != nil {
 		return nil, err
 	}
@@ -68,11 +68,12 @@ func (d *DayLog) Show(format string) (string, error) {
 }
 
 // returns the complete path to log file
-func resolveLogPath(year, month, day int) (string, error) {
+func resolveLogPath(project string, year, month, day int) (string, error) {
 	path, err := createDir(
 		xdg.DataHome,
 		filepath.Join(
 			"daylog",
+			project,
 			strconv.Itoa(year),
 			fmt.Sprintf("%02d", month),
 			fmt.Sprintf("%02d", day),


### PR DESCRIPTION
adds support for organizing different sets of logs into "projects". projects are just named subdirectories in daylong's data dir. the structure is now `$XDG_DATA_HOME/daylog/<project>/<year>/<month>/<day>/log.md`.

if a project is not specified with `-p` or `--project` a project named "default" is used.

closes https://github.com/notnmeyer/daylog-cli/issues/16