### PR TITLE
feat: `list` subcommand

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/notnmeyer/daylog-cli/internal/daylog"
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dl, err := daylog.New(args, config.Project)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = filepath.Walk(dl.ProjectPath, visit(dl.ProjectPath))
+		if err != nil {
+			fmt.Printf("error walking the path %v: %v\n", dl.ProjectPath, err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func visit(root string) filepath.WalkFunc {
+	rootDepth := strings.Count(root, string(os.PathSeparator))
+
+	return func(path string, info os.FileInfo, err error) error {
+		// print the error, but we want to continue the traversal
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+
+		depth := strings.Count(path, string(os.PathSeparator)) - rootDepth
+
+		var item string
+		if info.IsDir() {
+			item = info.Name() + "/"
+		} else {
+			item = info.Name()
+		}
+
+		fmt.Println(strings.Repeat("  ", depth), item)
+		return nil
+	}
+}

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -18,6 +18,9 @@ type DayLog struct {
 	// the complete path to the log file
 	Path string
 
+	// the path to the project directory
+	ProjectPath string
+
 	// the date of the log
 	Date *time.Time
 }
@@ -28,15 +31,21 @@ func New(args []string, project string) (*DayLog, error) {
 		return nil, err
 	}
 
+	projectPath, err := projectPath(project)
+	if err != nil {
+		return nil, err
+	}
+
 	year, month, day := t.Year(), int(t.Month()), t.Day()
-	file, err := resolveLogPath(project, year, month, day)
+	file, err := logPath(projectPath, year, month, day)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DayLog{
-		Path: file,
-		Date: t,
+		Path:        file,
+		ProjectPath: projectPath,
+		Date:        t,
 	}, nil
 }
 
@@ -68,12 +77,10 @@ func (d *DayLog) Show(format string) (string, error) {
 }
 
 // returns the complete path to log file
-func resolveLogPath(project string, year, month, day int) (string, error) {
+func logPath(path string, year, month, day int) (string, error) {
 	path, err := createDir(
-		xdg.DataHome,
+		path,
 		filepath.Join(
-			"daylog",
-			project,
 			strconv.Itoa(year),
 			fmt.Sprintf("%02d", month),
 			fmt.Sprintf("%02d", day),
@@ -84,6 +91,21 @@ func resolveLogPath(project string, year, month, day int) (string, error) {
 	}
 
 	return filepath.Join(path, "log.md"), nil
+}
+
+func projectPath(project string) (string, error) {
+	path, err := createDir(
+		xdg.DataHome,
+		filepath.Join(
+			"daylog",
+			project,
+		),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return path, nil
 }
 
 // resolves root path, and creates directories specified in path


### PR DESCRIPTION
adds a `list` subcommand to print an ugly tree view of a project,

```
✦ ➜ go run main.go list
 default/
   2023/
     09/
       29/
         log.md
     10/
       02/
         log.md
       13/
         log.md
     11/
       03/
         log.md
       09/
         log.md
       10/
         log.md
       11/
         log.md
       13/
         log.md
       21/
         log.md
```

useful for when you want to look back at a previous day but youre not sure what the date was