### PR TITLE
feat: info cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ go.work
 
 # Build directory
 dist/
+
+.env

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -25,14 +25,4 @@ var infoCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(infoCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// infoCmd represents the info command
 var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Display the full path to the logs directory.",

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -11,13 +11,8 @@ import (
 // infoCmd represents the info command
 var infoCmd = &cobra.Command{
 	Use:   "info",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Display the full path to the logs directory.",
+	Long:  "Display the full path to the logs directory.",
 	Run: func(cmd *cobra.Command, args []string) {
 		dl, err := daylog.New(args, config.Project)
 		if err != nil {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/notnmeyer/daylog-cli/internal/daylog"
+	"github.com/spf13/cobra"
+)
+
+// infoCmd represents the info command
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dl, err := daylog.New(args, config.Project)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("Log location: %s\n", dl.ProjectPath)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}


### PR DESCRIPTION
`daylog info (-p some-project)` displays the directory where the log files are located,

```
➜ tsk run -- info -p hello
Log location: /Users/nate/Library/Application Support/daylog/hello
```