### PR TITLE
feat: track logs in git

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -18,7 +18,7 @@ var infoCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		fmt.Printf("Log location: %s\n", dl.ProjectPath)
+		fmt.Println(dl.ProjectPath)
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/notnmeyer/daylog-cli/internal/daylog"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Creare a Git repository for your project.",
+	Long:  "Creare a Git repository for your project.",
+	Run: func(cmd *cobra.Command, args []string) {
+		dl, err := daylog.New(args, config.Project)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = dl.InitGitRepo()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// initCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// initCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -101,13 +101,6 @@ func (d *DayLog) InitGitRepo() error {
 	}
 	fmt.Println(output.Stdout.String())
 
-	// make an initial commit with any existing log files
-	output, err = git.AddAndCommit(d.ProjectPath, ".", "Initial commit")
-	if err != nil {
-		return fmt.Errorf("%s: %s", err, output.Stderr.String())
-	}
-	fmt.Println(output.Stdout.String())
-
 	return nil
 }
 

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -11,6 +11,7 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/markusmobius/go-dateparser"
 	"github.com/notnmeyer/daylog-cli/internal/editor"
+	"github.com/notnmeyer/daylog-cli/internal/git"
 	"github.com/notnmeyer/daylog-cli/internal/output-formatter"
 )
 
@@ -74,6 +75,31 @@ func (d *DayLog) Show(format string) (string, error) {
 	}
 
 	return contents, nil
+}
+
+func (d *DayLog) InitGitRepo() error {
+	// check if a repo exists for the project
+	if exists, err := git.RepoExists(d.ProjectPath); exists {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("%s already appears to be a git repo\n", d.ProjectPath)
+	}
+
+	// init a new repo
+	repo, err := git.Init(d.ProjectPath)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("initialized Git repository %s\n", repo)
+
+	// make an initial commit with any existing log files
+	err = git.AddAndCommit(d.ProjectPath, ".", "Initial")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // returns the complete path to log file

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -60,6 +60,11 @@ func (d *DayLog) Edit() error {
 		return err
 	}
 
+	if d.gitEnabled() {
+		msg := fmt.Sprintf("update log for %d/%d/%d\n", d.Date.Year(), int(d.Date.Month()), d.Date.Day())
+		git.AddAndCommit(d.ProjectPath, d.Path, msg)
+	}
+
 	return nil
 }
 
@@ -100,6 +105,11 @@ func (d *DayLog) InitGitRepo() error {
 	}
 
 	return nil
+}
+
+func (d *DayLog) gitEnabled() bool {
+	exists, _ := git.RepoExists(d.ProjectPath)
+	return exists
 }
 
 // returns the complete path to log file

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -94,7 +94,7 @@ func (d *DayLog) InitGitRepo() error {
 	fmt.Printf("initialized Git repository %s\n", repo)
 
 	// make an initial commit with any existing log files
-	err = git.AddAndCommit(d.ProjectPath, ".", "Initial")
+	err = git.AddAndCommit(d.ProjectPath, ".", "Initial commit")
 	if err != nil {
 		return err
 	}

--- a/internal/daylog/daylog.go
+++ b/internal/daylog/daylog.go
@@ -62,7 +62,10 @@ func (d *DayLog) Edit() error {
 
 	if d.gitEnabled() {
 		msg := fmt.Sprintf("update log for %d/%d/%d\n", d.Date.Year(), int(d.Date.Month()), d.Date.Day())
-		git.AddAndCommit(d.ProjectPath, d.Path, msg)
+		output, err := git.AddAndCommit(d.ProjectPath, d.Path, msg)
+		if err != nil {
+			return fmt.Errorf("%s: %s", err, output.Stderr.String())
+		}
 	}
 
 	return nil
@@ -92,17 +95,18 @@ func (d *DayLog) InitGitRepo() error {
 	}
 
 	// init a new repo
-	repo, err := git.Init(d.ProjectPath)
+	output, err := git.Init(d.ProjectPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %s", err, output.Stderr.String())
 	}
-	fmt.Printf("initialized Git repository %s\n", repo)
+	fmt.Println(output.Stdout.String())
 
 	// make an initial commit with any existing log files
-	err = git.AddAndCommit(d.ProjectPath, ".", "Initial commit")
+	output, err = git.AddAndCommit(d.ProjectPath, ".", "Initial commit")
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %s", err, output.Stderr.String())
 	}
+	fmt.Println(output.Stdout.String())
 
 	return nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,76 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// returns true if dit contains a git repo
+func RepoExists(dir string) (bool, error) {
+	gitDir := filepath.Join(dir, ".git")
+
+	info, err := os.Stat(gitDir)
+	switch {
+	case os.IsNotExist(err):
+		return false, nil
+	case err != nil:
+		return false, err
+	case !info.IsDir():
+		return false, fmt.Errorf("%s is not a directory\n", gitDir)
+	}
+
+	return true, nil
+}
+
+func Init(dir string) (string, error) {
+	err := runCmd("init", dir)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, ".git"), nil
+}
+
+func Add(dir, pattern string) error {
+	err := runCmd("-C", dir, "add", pattern)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Commit(dir, msg string) error {
+	err := runCmd("-C", dir, "commit", "-m", msg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func AddAndCommit(dir, pattern, msg string) error {
+	err := Add(dir, pattern)
+	if err != nil {
+		return err
+	}
+
+	err = Commit(dir, msg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// exec a git command
+func runCmd(args ...string) error {
+	cmd := exec.Command("git", args...)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
also optional tracking of log files in a git repo.

`daylog init -p project` will create a new git repo for the specified project. if a project has a repo, log updates are committed automatically.