### PR TITLE
fix: dont set cgo env

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,9 +5,7 @@ before:
     - go mod tidy
 
 builds:
-  - env:
-      - CGO_ENABLED=0
-    goos:
+  - goos:
       - linux
       - darwin
     binary: daylog


### PR DESCRIPTION
local builds worked but the goreleaser builds didn't work for me on macos,

```
 ➜ dist/daylog-cli_darwin_amd64_v1/daylog copy
panic: clipboard: cannot use when CGO_ENABLED=0

goroutine 1 [running]:
golang.design/x/clipboard.write(...)
        /Users/nate/go/pkg/mod/golang.design/x/clipboard@v0.7.0/clipboard_nocgo.go:21
golang.design/x/clipboard.Write(0x4addae0?, {0x4313d8d?, 0x4?, 0x4321ec6?})
        /Users/nate/go/pkg/mod/golang.design/x/clipboard@v0.7.0/clipboard.go:138 +0x7f
github.com/notnmeyer/daylog-cli/cmd.copy(...)
        /Users/nate/code/daylog-cli/cmd/copy.go:41
github.com/notnmeyer/daylog-cli/cmd.init.func1(0xc001bc6100?, {0x4addae0?, 0x4?, 0x4313d95?})
        /Users/nate/code/daylog-cli/cmd/copy.go:27 +0xfc
github.com/spf13/cobra.(*Command).execute(0x4a81fe0, {0x4addae0, 0x0, 0x0})
        /Users/nate/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xabb
github.com/spf13/cobra.(*Command).ExecuteC(0x4a82b60)
        /Users/nate/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x44f
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/nate/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/notnmeyer/daylog-cli/cmd.Execute({0x44f2b28?, 0x0?}, {0x44f3320?, 0xc000002380?})
        /Users/nate/code/daylog-cli/cmd/root.go:55 +0x6b
main.main()
        /Users/nate/code/daylog-cli/main.go:8 +0x2f
```